### PR TITLE
Variable interval width via downsampling [Experimental]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -870,6 +870,49 @@
                 "--verbose",
                 "true"
             ]
-        }
+        },
+        {
+            "name": "Debug [Internal] - Sort brightness - Interval brightness - Downsample 0.05% (image-test.png)",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cli",
+            "console": "integratedTerminal",
+            "args": [
+                "image",
+                "--sort-determinant",
+                "brightness",
+                "--input-media-path",
+                "image-test.png",
+                "--output-media-path",
+                "image-test-sorted.jpg",
+                "--direction",
+                "ascending",
+                "--interval-determinant",
+                "brightness",
+                "--interval-lower-threshold",
+                "0.15",
+                "--interval-upper-threshold",
+                "0.85",
+                "--interval-max-length",
+                "0",
+                "--interval-max-length-random-factor",
+                "0",
+                "--order",
+                "horizontal-vertical",
+                "--angle",
+                "0",
+                "--cycles",
+                "1",
+                "--scale",
+                "1",
+                "--downsample",
+                "0.005",
+                "--blending-mode",
+                "none",
+                "--verbose",
+                "true"
+            ]
+        },
     ]
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	FlagBlendingMode               string
 	FlagVerboseLogging             bool
 	FlagIntervalLengthRandomFactor int
+	FlagDownsample                 float64
 )
 
 var (
@@ -93,6 +94,8 @@ func init() {
 	rootCmd.PersistentFlags().Float64VarP(&FlagImageScale, "scale", "s", 1, "Image downscaling percentage factor. Options: [0.0 - 1.0].")
 
 	rootCmd.PersistentFlags().StringVarP(&FlagBlendingMode, "blending-mode", "b", "none", "The blending mode algorithm to blend the sorted image into the original. Options: [none, lighten, darken].")
+
+	rootCmd.PersistentFlags().Float64VarP(&FlagDownsample, "downsample", "n", 0, "Image downsampling percentage factor. Options: [0.0 - 1.0].")
 }
 
 // Helper function used to validate and apply flag values into the sorter options struct
@@ -214,6 +217,7 @@ func parseCommonOptions() (*sorter.SorterOptions, error) {
 	options.Angle = FlagAngle
 	options.Cycles = FlagSortCycles
 	options.Scale = FlagImageScale
+	options.Downsample = FlagDownsample
 
 	if FlagMask && len(FlagMaskImageFilePath) == 0 {
 		LocalLogger.Warnf("The mask flag is set, but not mask file has been specified.")

--- a/pkg/sorter/defaultSorter.go
+++ b/pkg/sorter/defaultSorter.go
@@ -107,6 +107,11 @@ func (sorter *defaultSorter) Sort() (image.Image, error) {
 		return nil, fmt.Errorf("sorter: the provided image is not drawable: %w", err)
 	}
 
+	if sorter.options.Downsample != 0 {
+		factor := int(sorter.options.Downsample * float64(drawableImage.Bounds().Dx()))
+		drawableImage = utils.Downsample(drawableImage, factor)
+	}
+
 	if sorter.options.Angle != 0 {
 		drawableImage = utils.RotateImage(drawableImage, sorter.options.Angle)
 	}

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -83,6 +83,7 @@ type SorterOptions struct {
 	Cycles                            int
 	Scale                             float64
 	Blending                          ResultImageBlending
+	Downsample                        float64
 }
 
 // Return a boolean value indicating if the given sorter options combination is valid
@@ -116,6 +117,10 @@ func (options *SorterOptions) AreValid() (bool, string) {
 		return false, "the interval length random factor value must not be negative"
 	}
 
+	if options.Downsample < 0.0 || options.Downsample > 1.0 {
+		return false, "the downsample factor must be between values 0 and 1"
+	}
+
 	return true, ""
 }
 
@@ -136,6 +141,7 @@ func GetDefaultSorterOptions() *SorterOptions {
 	options.Cycles = 1
 	options.Scale = 1
 	options.Blending = BlendingNone
+	options.Downsample = 0
 
 	return options
 }

--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -344,3 +344,46 @@ func BlendImages(a, b image.Image, mode BlendingMode) (draw.Image, error) {
 
 	return resultImage, nil
 }
+
+// Create a downsampled version of the provided image. The f parameter indicated the sampling step.
+// The upper left color of a sampling step is used to fill the whole sample. This function will panic
+// if the provided image is nil or if the downsampling factor is less than zero.
+func Downsample(i image.Image, f int) draw.Image {
+	if i == nil {
+		panic("image-utils: the provided image reference is nil")
+	}
+
+	if f < 0 {
+		panic("image-utils: the downsampling factor must not be less than zero")
+	}
+
+	if f < 2 {
+		if img, err := GetDrawableImage(i); err != nil {
+			panic(fmt.Errorf("image-utils: failed to perform the zero factor downsampling: %w", err))
+		} else {
+			return img
+		}
+	}
+
+	img := image.NewRGBA(i.Bounds())
+	for xIndex := 0; xIndex < img.Bounds().Dx(); xIndex += f {
+		for yIndex := 0; yIndex < img.Bounds().Dy(); yIndex += f {
+			c := i.At(xIndex, yIndex)
+
+			for xxIndex := 0; xxIndex < f; xxIndex += 1 {
+				for yyIndex := 0; yyIndex < f; yyIndex += 1 {
+					xOffset := xIndex + xxIndex
+					yOffset := yIndex + yyIndex
+
+					if xOffset >= img.Bounds().Dx() || yOffset >= img.Bounds().Dy() {
+						continue
+					} else {
+						img.Set(xOffset, yOffset, c)
+					}
+				}
+			}
+		}
+	}
+
+	return img
+}

--- a/pkg/utils/image_test.go
+++ b/pkg/utils/image_test.go
@@ -347,6 +347,104 @@ const (
 	mock_image_height = 25
 )
 
+func TestDownsampleShouldPanicForNilImage(t *testing.T) {
+	assert.Panics(t, func() {
+		Downsample(nil, 2)
+	})
+}
+
+func TestDownsampleShouldPanicForInvalidFactor(t *testing.T) {
+	assert.Panics(t, func() {
+		Downsample(mockTestWhiteImage(), -1)
+	})
+}
+
+func TestDownsampleShouldDownsampleImageWithFactorZero(t *testing.T) {
+	expectedImage := mockTestGradientImage()
+
+	actualImage := Downsample(expectedImage, 0)
+
+	StoreImageToFile("expected.png", "png", expectedImage)
+	StoreImageToFile("actual.png", "png", actualImage)
+
+	assert.NotNil(t, actualImage)
+	assert.Equal(t, expectedImage, actualImage)
+}
+
+func TestDownsampleShouldDownsampleImageWithFactorOne(t *testing.T) {
+	expectedImage := mockTestGradientImage()
+
+	actualImage := Downsample(expectedImage, 1)
+
+	StoreImageToFile("expected.png", "png", expectedImage)
+	StoreImageToFile("actual.png", "png", actualImage)
+
+	assert.NotNil(t, actualImage)
+	assert.Equal(t, expectedImage, actualImage)
+}
+
+func TestDownsampleShouldDownsampleImageWithFactorEven(t *testing.T) {
+	inputImage := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	expectedImage := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	sw := false
+	for y := 0; y < 4; y += 1 {
+		for x := 0; x < 4; x += 1 {
+			expectedImage.Set(x, y, color.White)
+
+			if sw {
+				inputImage.Set(x, y, color.Black)
+			} else {
+				inputImage.Set(x, y, color.White)
+			}
+			sw = !sw
+		}
+	}
+
+	actualImage := Downsample(inputImage, 2)
+
+	assert.NotNil(t, actualImage)
+	assert.Equal(t, expectedImage, actualImage)
+}
+
+func TestDownsampleShouldDownsampleImageWithFactorOdd(t *testing.T) {
+	inputImage := image.NewRGBA(image.Rect(0, 0, 5, 4))
+	expectedImage := image.NewRGBA(image.Rect(0, 0, 5, 4))
+	sw := false
+	for y := 0; y < 4; y += 1 {
+		for x := 0; x < 5; x += 1 {
+			expectedImage.Set(x, y, color.Black)
+
+			if sw {
+				inputImage.Set(x, y, color.White)
+			} else {
+				inputImage.Set(x, y, color.Black)
+			}
+			sw = !sw
+		}
+	}
+
+	actualImage := Downsample(inputImage, 2)
+
+	assert.NotNil(t, actualImage)
+	assert.Equal(t, expectedImage, actualImage)
+}
+func TestDownsampleShouldDownsampleImageWithFactorGreaterThanDimensions(t *testing.T) {
+	inputImage := mockTestWhiteImage()
+	inputImage.Set(0, 0, color.Black)
+
+	expectedImage := image.NewRGBA(inputImage.Bounds())
+	for y := 0; y < inputImage.Bounds().Dy(); y += 1 {
+		for x := 0; x < inputImage.Bounds().Dx(); x += 1 {
+			expectedImage.Set(x, y, color.Black)
+		}
+	}
+
+	actualImage := Downsample(inputImage, inputImage.Bounds().Dx()*2)
+
+	assert.NotNil(t, actualImage)
+	assert.Equal(t, expectedImage, actualImage)
+}
+
 // Create a test image which is a linear, left to right, black to white gradient of the size specifed by the mock_image prefixed constants
 func mockTestGradientImage() draw.Image {
 	gradient := make([]color.Color, mock_image_width)


### PR DESCRIPTION
Second attempt at variable interval width implementation. Currently, the whole image is affected by downsampling, which causes the loss of detail in parts that do not belong to any intervals.

We can fix it by introducing further changes to the interval algorithm, or we can set up a double buffered result image (one downsampled, used for sorting and a second one used for output default values).